### PR TITLE
Add savon as dependency

### DIFF
--- a/roles_db.gemspec
+++ b/roles_db.gemspec
@@ -24,6 +24,8 @@ Gem::Specification.new do |spec|
   spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "savon"
+
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
This gem require's savon but did not list it as a dependency.
